### PR TITLE
Restructure into Custom Service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,13 +1771,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "poise",
- "serenity",
- "shuttle-poise",
  "shuttle-runtime",
  "shuttle-secrets",
- "shuttle-serenity",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2274,16 +2270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shuttle-poise"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f088f659d316f9be9425491b24bfc8f8a69fcb6cc3d728cd07b95b31bc61424"
-dependencies = [
- "poise",
- "shuttle-runtime",
-]
-
-[[package]]
 name = "shuttle-proto"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,16 +2326,6 @@ dependencies = [
  "secrecy",
  "serde",
  "shuttle-service",
-]
-
-[[package]]
-name = "shuttle-serenity"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f71105d9f2ec8b4e4933a0ad9d57058f44ae5f5832c4cc32c3a9262b78aa65"
-dependencies = [
- "serenity",
- "shuttle-runtime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.66"
-shuttle-serenity = "0.32.0"
 shuttle-runtime = "0.32.0"
-serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "cache"] }
 shuttle-secrets = "0.32.0"
 tokio = "1.26.0"
-tracing = "0.1.37"
 poise = "0.5.7"
-shuttle-poise = "0.32.0"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,5 @@
-use crate::{Context, Error};
+use crate::Error;
+type Context<'a> = poise::Context<'a, crate::Data, Error>;
 
 /// Ping, Pong
 #[poise::command(slash_command)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,5 @@
-use crate::Error;
 type Context<'a> = poise::Context<'a, crate::Data, Error>;
+type Error = Box<dyn std::error::Error + Send + Sync>;
 
 /// Ping, Pong
 #[poise::command(slash_command)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ mod commands;
 // Needed for Poise
 pub struct Data {}
 type Error = Box<dyn std::error::Error + Send + Sync>;
-type Context<'a> = poise::Context<'a, Data, Error>;
 
 #[shuttle_runtime::main]
 async fn razzbot(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::Context;
 use poise::serenity_prelude as serenity;
 use shuttle_poise::ShuttlePoise;
 use shuttle_secrets::SecretStore;
@@ -10,13 +10,9 @@ type Error = Box<dyn std::error::Error + Send + Sync>;
 
 #[shuttle_runtime::main]
 async fn razzbot(
-	#[shuttle_secrets::Secrets] secret_store: SecretStore,
+	#[shuttle_secrets::Secrets] secrets: SecretStore,
 ) -> ShuttlePoise<Data, Error> {
-	let token = if let Some(token) = secret_store.get("DISCORD_TOKEN") {
-		token
-	} else {
-		return Err(anyhow!("'DISCORD_TOKEN' was not found").into());
-	};
+	let token = secrets.get("DISCORD_TOKEN").context("'DISCORD_TOKEN' not found")?;
 	let framework = poise::Framework::builder()
 		.options(poise::FrameworkOptions {
 			commands: vec![commands::ping()],


### PR DESCRIPTION
Initial restructuring of the existing bot from a shuttle_poise service into a custom shuttle service, to allow for multiple different services to be used. In this case, I'm expecting to use some sort of web framework (likely axum, but who knows at this moment) to implement webhook listeners that can pass received notifications over to the discord bot. Will likely need to restructure a few things further down the line, such as extracting out the build instruction for the bot to obtain a CacheAndHttp object to throw to the axum server for interacting with the Discord API, but for now this is fine.